### PR TITLE
Remoção do using namespace nas classes

### DIFF
--- a/EP2/Ponto.cpp
+++ b/EP2/Ponto.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include "Ponto.h"
-using namespace std;
 
 Ponto::Ponto(double x, double y) : x (x), y (y) {}
 
@@ -15,7 +14,7 @@ double Ponto::getY() {
 }
 
 void Ponto::imprimir() {
-    cout << "(" << getX() << ", " << getY() << ")" << endl;
+    std::cout << "(" << getX() << ", " << getY() << ")" << std::endl;
 }
 
 bool Ponto::eIgual(Ponto* outro) {

--- a/EP2/Serie.cpp
+++ b/EP2/Serie.cpp
@@ -1,6 +1,8 @@
 #include "Serie.h"
 #include <iostream>
-using namespace std;
+using std::string;
+using std::cout;
+using std::endl;
 
 Serie::Serie(string nome, string nomeDoCanalX, string nomeDoCanalY) :
     nome (nome), nomeDoCanalX (nomeDoCanalX), nomeDoCanalY (nomeDoCanalY) {}

--- a/EP2/Serie.h
+++ b/EP2/Serie.h
@@ -6,24 +6,22 @@
 #include <string>
 #include "Ponto.h"
 
-using namespace std;
-
 class Serie {
     protected:
-        string nome, nomeDoCanalX, nomeDoCanalY;
+        std::string nome, nomeDoCanalX, nomeDoCanalY;
         double eixoX[NUMERO_MAXIMO_VALORES], eixoY[NUMERO_MAXIMO_VALORES];
         int quantidade = 0;
     public:
         /**
         * Cria uma Serie informando o nome dela e o nome dos canais X e Y.
         */
-        Serie(string nome, string nomeDoCanalX, string nomeDoCanalY);
+        Serie(std::string nome, std::string nomeDoCanalX, std::string nomeDoCanalY);
         virtual ~Serie();
 
         // Permite obter o nome, o nomeDoCanalX e o nomeDoCanalY.
-        virtual string getNome();
-        virtual string getNomeDoCanalX();
-        virtual string getNomeDoCanalY();
+        virtual std::string getNome();
+        virtual std::string getNomeDoCanalX();
+        virtual std::string getNomeDoCanalY();
 
         /**
         * Informa a quantidade de pontos que a Serie possui.

--- a/EP2/SerieTemporal.cpp
+++ b/EP2/SerieTemporal.cpp
@@ -1,13 +1,13 @@
 #include "SerieTemporal.h"
 #include <cmath>
 
-SerieTemporal::SerieTemporal(string nome, string nomeDoCanalY) : Serie (nome, "Tempo", nomeDoCanalY) {}
+SerieTemporal::SerieTemporal(std::string nome, std::string nomeDoCanalY) : Serie (nome, "Tempo", nomeDoCanalY) {}
 
 SerieTemporal::~SerieTemporal() {}
 
 void SerieTemporal::adicionar(double valor) {
     for (int i = 0; i < quantidade; i++)
-        if (abs((getPosicao(i)->getX()) - tempo) <= 1e-5) {
+        if (std::abs((getPosicao(i)->getX()) - tempo) <= 1e-5) {
             eixoY[i] = valor;
             tempo += 1;
             return;
@@ -19,7 +19,7 @@ void SerieTemporal::adicionar(double valor) {
 
 void SerieTemporal::adicionar(double x, double y) {
     for (int i = 0; i < quantidade; i++)
-        if (abs(getPosicao(i)->getX() - x) <= 1e-5) {
+        if (std::abs(getPosicao(i)->getX() - x) <= 1e-5) {
             eixoY[i] = y;
             return;
         }

--- a/EP2/SerieTemporal.h
+++ b/EP2/SerieTemporal.h
@@ -1,9 +1,7 @@
 #ifndef SERIETEMPORAL_H
 #define SERIETEMPORAL_H
-#define NUMERO_MAXIMO_VALORES 10
 
 #include "Serie.h"
-
 
 class SerieTemporal : public Serie {
     protected:
@@ -13,23 +11,23 @@ class SerieTemporal : public Serie {
         * Cria uma SerieTemporal informando o nome da Serie e o nome do
         * canalY. O nome do canal X deve ser obrigatoriamente "Tempo".
         */
-        SerieTemporal(string nome, string nomeDoCanalY);
+        SerieTemporal(std::string nome, std::string nomeDoCanalY);
         virtual ~SerieTemporal();
 
         /**
         * Adiciona um novo Ponto a Serie, no instante seguinte ao do
-        * ponto anterior adicionado por este mÈtodo. O primeiro ponto
+        * ponto anterior adicionado por este m√©todo. O primeiro ponto
         * deve ser adicionado no instante 1.
         */
         virtual void adicionar(double valor);
 
         /**
         * Adiciona um Ponto a Serie informando a coordenada x e y.
-        * Caso j· exista um ponto cuja coordenada x seja suficientemente
-        * prÛxima ao do valor x informado, ao invÈs e adicionar o ponto,
-        * altere o valor anterior (mantendo sua posiÁ„o no arranjo)
+        * Caso j√° exista um ponto cuja coordenada x seja suficientemente
+        * pr√≥xima ao do valor x informado, ao inv√©s e adicionar o ponto,
+        * altere o valor anterior (mantendo sua posi√ß√£o no arranjo)
         * ao considerar a nova coordenada y.
-        * Caso a coordenada x do ponto for < 1, o ponto n„o deve ser adicionado.
+        * Caso a coordenada x do ponto for < 1, o ponto n√£o deve ser adicionado.
         */
         virtual void adicionar(double x, double y);
 };


### PR DESCRIPTION
Adição de "std::" para compensar a remoção de "using namespace std;".